### PR TITLE
keep input order stable

### DIFF
--- a/tools/tool_scripts/pubchemID2SDF.R
+++ b/tools/tool_scripts/pubchemID2SDF.R
@@ -25,9 +25,7 @@ if(! exists("debug_mode")){
 
 #print("ids: ")
 #print(pubchemIds)
-print(paste(pubchemIds,collapse=","))
+#print(paste(pubchemIds,collapse=","))
 
 compoundIds = findCompoundsByName(conn,pubchemIds,keepOrder=TRUE,allowMissing=TRUE)
-#compoundIds = findCompoundsByName(conn,pubchemIds,allowMissing=TRUE)
-print(paste(compoundIds,collapse=","))
-getCompounds(conn,compoundIds,filename=outfile)
+getCompounds(conn,compoundIds,filename=outfile,keepOrder=TRUE)


### PR DESCRIPTION
I have upgraded ChemmineR to 2.13.9 and added the keepOrder option to two calls to maintain the input order.
