### PR TITLE
Develop

### DIFF
--- a/tools/tool_scripts/eiSearchServer.R
+++ b/tools/tool_scripts/eiSearchServer.R
@@ -37,8 +37,8 @@ loadTestSet <- function(){
 		eiQuery(r=r,d=d,refIddb=refIddb,dir=basedir,lshData=lshData,mainIds=mainIds,...)
 }
 
-queryFn = loadTestSet()
-#queryFn = loadPubchem()
+#queryFn = loadTestSet()
+queryFn = loadPubchem()
 
 
 while(1) {

--- a/tools/tool_scripts/eiSearchServer.init
+++ b/tools/tool_scripts/eiSearchServer.init
@@ -23,8 +23,9 @@ DESC="eiSearch Query Server"
 NAME=eiSearchServer
 ROOTNAME=R
 DAEMON=/srv/chemminetools/tools/tool_scripts/$NAME.R
+#DAEMON=/home/khoran/repositories/chemminetools/tools/tool_scripts/$NAME.sh
 DAEMON_ARGS=""
-PIDFILE=/var/run/$NAME.pid
+PIDFILE=/var/run/$NAME/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed
@@ -50,9 +51,9 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -m -b --test > /dev/null \
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid nobody  --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -m -b -- \
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON  --chuid nobody -- \
 		$DAEMON_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready

--- a/tools/tool_scripts/eiSearchServer.sh
+++ b/tools/tool_scripts/eiSearchServer.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DIR=$(dirname $0)
+
+$DIR/eiSearchServer.R 2>&1|logger --id --tag eiSearchServer &
+
+PID=$(jobs -p)
+
+#echo pid $PID
+
+echo $PID > /var/run/eiSearchServer/eiSearchServer.pid


### PR DESCRIPTION
I have add an init script now. I have already placed a copy in /etc/init.d but it is pointing to stuff that won't exist until you merge this branch in. So after you have done that you should execute: "/etc/init.d/eiSearchServer start" to start the server. The errors you were getting were caused by the wrong version of eiR being installed, namely, I had installed a development version that worked with the server, but at some point the latest bioc version got installed on top of it. I will have the version that works merged into bioc either today or tomorrow so it should not be a problem again. 
